### PR TITLE
Support utf16

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ util.inherits(ZongJi, EventEmitter);
 ZongJi.prototype._establishConnection = function(dsn) {
   const createConnection = (options) => {
     let connection = mysql.createConnection(options);
+    connection.query("SET NAMES utf8")
     connection.on('error', this.emit.bind(this, 'error'));
     connection.on('unhandledError', this.emit.bind(this, 'error'));
     // don't need to call connection.connect() here

--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ util.inherits(ZongJi, EventEmitter);
 ZongJi.prototype._establishConnection = function(dsn) {
   const createConnection = (options) => {
     let connection = mysql.createConnection(options);
-    connection.query("SET NAMES utf8")
     connection.on('error', this.emit.bind(this, 'error'));
     connection.on('unhandledError', this.emit.bind(this, 'error'));
     // don't need to call connection.connect() here

--- a/lib/common.js
+++ b/lib/common.js
@@ -445,12 +445,10 @@ exports.readMysqlValue = function(
       } else {
         if(column.charset !== null) {
           // Javascript UTF8 always allows up to 4 bytes per character
-          if (column.charset === 'utf8mb4' || column.charset === 'utf8mb3') {
-            column.charset = 'utf-8'
-          } else if (column.charset === 'utf16') {
-            // Javascript only supports utf16le
-            column.charset = 'utf-16le'
-          }
+          // if (column.charset === 'utf8mb4' || column.charset === 'utf8mb3') {
+          //   column.charset = 'utf-8'
+          // }
+          column.charset = 'utf-8'
           parser._encoding = column.charset;
         }
         result = parser.parseString(size);

--- a/lib/common.js
+++ b/lib/common.js
@@ -449,9 +449,8 @@ exports.readMysqlValue = function(
             column.charset = 'utf-8'
           } else if (column.charset === 'utf16') {
             // Convert to utf16le as Buffer only supports utf16le
-            result = parser.parseBuffer(size).swap16();
-            result = result.toString('utf16le');
-            return result
+            result = parser.parseBuffer(size).swap16().toString('utf16le');
+            break;
           }
           parser._encoding = column.charset;
         }

--- a/lib/common.js
+++ b/lib/common.js
@@ -444,8 +444,15 @@ exports.readMysqlValue = function(
         result = parser.parseBuffer(size);
       } else {
         if(column.charset !== null) {
-          column.charset = column.charset === 'utf8mb4' ? 'utf8' : column.charset;
-          column.charset = column.charset === 'utf8mb3' ? 'utf8' : column.charset;
+          // Javascript UTF8 always allows up to 4 bytes per character
+          if (column.charset === 'utf8mb4' || column.charset === 'utf8mb3') {
+            column.charset = 'utf-8'
+          } else if (column.charset === 'utf16') {
+            // Convert to utf16le as Buffer only supports utf16le
+            result = parser.parseBuffer(size).swap16();
+            result = result.toString('utf16le');
+            return result
+          }
           parser._encoding = column.charset;
         }
         result = parser.parseString(size);

--- a/lib/common.js
+++ b/lib/common.js
@@ -445,8 +445,12 @@ exports.readMysqlValue = function(
       } else {
         if(column.charset !== null) {
           // Javascript UTF8 always allows up to 4 bytes per character
-          column.charset = column.charset === 'utf8mb4' ? 'utf8' : column.charset;
-          column.charset = column.charset === 'utf8mb3' ? 'utf8' : column.charset;
+          if (column.charset === 'utf8mb4' || column.charset === 'utf8mb3') {
+            column.charset = 'utf-8'
+          } else if (column.charset === 'utf16') {
+            // Javascript only supports utf16le
+            column.charset = 'utf-16le'
+          }
           parser._encoding = column.charset;
         }
         result = parser.parseString(size);

--- a/lib/common.js
+++ b/lib/common.js
@@ -444,11 +444,8 @@ exports.readMysqlValue = function(
         result = parser.parseBuffer(size);
       } else {
         if(column.charset !== null) {
-          // Javascript UTF8 always allows up to 4 bytes per character
-          // if (column.charset === 'utf8mb4' || column.charset === 'utf8mb3') {
-          //   column.charset = 'utf-8'
-          // }
-          column.charset = 'utf-8'
+          column.charset = column.charset === 'utf8mb4' ? 'utf8' : column.charset;
+          column.charset = column.charset === 'utf8mb3' ? 'utf8' : column.charset;
           parser._encoding = column.charset;
         }
         result = parser.parseString(size);


### PR DESCRIPTION
## Description
Nodejs buffer only supports utf16le. This adds support to utf16be as well by swapping the byte order.

## Fix
- Use `Buffer.swap16()` to convert le to be. Reference [here](https://gist.github.com/zoellner/4af04a5a8b51f04ad653e26d3b7181ec).

## Todo
- [ ] Implement Fix