### PR TITLE
[Fix] Do not change timestamp to UTC when dateStrings is on

### DIFF
--- a/lib/datetime_decode.js
+++ b/lib/datetime_decode.js
@@ -76,7 +76,7 @@ exports.getDateTime = function(dateStrings, // node-mysql dateStrings option,
 )
 {
   if (!useDateStringsForType(dateStrings, 'DATETIME')) {
-    const momentDate = moment.tz({ y: year, M: jsMonthFromMysqlMonth(month), d: date, h: hour, m: minute, s: second, ...(fraction ? { ms: fraction.milliseconds } : {}) }, 'Etc/UTC');
+    const momentDate = moment.tz({ y: year, M: jsMonthFromMysqlMonth(month), d: date, h: hour, m: minute, s: second, ...(fraction ? { ms: fraction.milliseconds } : {}) }, timezone);
     return momentDate.toDate();
   }
   return getDateString(year, month, date) + ' ' +
@@ -100,7 +100,7 @@ exports.getTimeStamp = function(dateStrings, // node-mysql dateStrings option
   const milliseconds = fraction ? fraction.milliseconds : 0;
   const dateObject = moment.tz(secondsFromEpoch * 1000 + milliseconds, timezone);
   if (!useDateStringsForType(dateStrings, 'TIMESTAMP')) {
-    // We need to return a Date object, because the dateStrings option is not set. toDate() will convert the timezone to UTC(Z).
+    // We need to return a Date object, because the dateStrings option is not set, .toDate() will convert the timezone to UTC(Z).
     return dateObject.toDate();
   }
   if (secondsFromEpoch === 0 && (!fraction || fraction.value === 0)) {

--- a/lib/datetime_decode.js
+++ b/lib/datetime_decode.js
@@ -98,18 +98,18 @@ exports.getTimeStamp = function(dateStrings, // node-mysql dateStrings option
 )
 {
   const milliseconds = fraction ? fraction.milliseconds : 0;
-  const dateObject = moment.tz(secondsFromEpoch * 1000 + milliseconds, timezone).toDate();
+  const dateObject = moment.tz(secondsFromEpoch * 1000 + milliseconds, timezone);
   if (!useDateStringsForType(dateStrings, 'TIMESTAMP')) {
-    return dateObject;
+    return dateObject.toDate();
   }
   if (secondsFromEpoch === 0 && (!fraction || fraction.value === 0)) {
     return '0000-00-00 00:00:00' + getFractionString(fraction);
   }
-  return getDateString(dateObject.getFullYear(),
-      dateObject.getMonth() + 1,
-      dateObject.getDate()) + ' ' +
-    common.zeroPad(dateObject.getHours(), 2) + ':' +
-    common.zeroPad(dateObject.getMinutes(), 2) + ':' +
-    common.zeroPad(dateObject.getSeconds(), 2) +
+  return getDateString(dateObject.year(),
+      dateObject.month() + 1,
+      dateObject.date()) + ' ' +
+    common.zeroPad(dateObject.hour(), 2) + ':' +
+    common.zeroPad(dateObject.minute(), 2) + ':' +
+    common.zeroPad(dateObject.second(), 2) +
     getFractionString(fraction);
 };

--- a/lib/datetime_decode.js
+++ b/lib/datetime_decode.js
@@ -76,7 +76,7 @@ exports.getDateTime = function(dateStrings, // node-mysql dateStrings option,
 )
 {
   if (!useDateStringsForType(dateStrings, 'DATETIME')) {
-    const momentDate = moment.tz({ y: year, M: jsMonthFromMysqlMonth(month), d: date, h: hour, m: minute, s: second, ...(fraction ? { ms: fraction.milliseconds } : {}) }, timezone);
+    const momentDate = moment.tz({ y: year, M: jsMonthFromMysqlMonth(month), d: date, h: hour, m: minute, s: second, ...(fraction ? { ms: fraction.milliseconds } : {}) }, 'Etc/UTC');
     return momentDate.toDate();
   }
   return getDateString(year, month, date) + ' ' +
@@ -100,6 +100,7 @@ exports.getTimeStamp = function(dateStrings, // node-mysql dateStrings option
   const milliseconds = fraction ? fraction.milliseconds : 0;
   const dateObject = moment.tz(secondsFromEpoch * 1000 + milliseconds, timezone);
   if (!useDateStringsForType(dateStrings, 'TIMESTAMP')) {
+    // We need to return a Date object, because the dateStrings option is not set. toDate() will convert the timezone to UTC(Z).
     return dateObject.toDate();
   }
   if (secondsFromEpoch === 0 && (!fraction || fraction.value === 0)) {


### PR DESCRIPTION
# Description
When the dateString option is on, the date will keep the timezone provided by the override. (Default is Etc/UTC)
Calling moment.toDate() makes the string transform to a UTC timezone datetime.
This change would not affect any other pipeline that does not have the dateStrings options turned on.
